### PR TITLE
Treat tests that throw an exception as failed and continue the run

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,15 @@ function prova (title, fn) {
   if (command.browser) return;
   if (command.grep && title.indexOf(command.grep) == -1) return skip(title, fn);
   if (isNode) tests.add(title);
-  return tape(title, fn);
+  return tape(title, function (assert) {
+    try {
+      fn.apply(this, arguments);
+    } catch (err) {
+      assert.error(err);
+      assert.end();
+      return;
+    }
+  });
 }
 
 function skip (title, fn) {


### PR DESCRIPTION
Fixes behaviour of tests that throw exceptions to be same as before tape 3.0.0 upgrade by reporting them as failed tests and continuing the run instead of crashing. 

Fixes #38
