### PR TITLE
Prevents rogue browser process when using --launch --headless --quit

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -20,6 +20,10 @@ function launch (url, options) {
     start(url, options, function (error, ps) {
       if (error) return console.error(error);
 
+      process.on('exit', function(code) {
+        ps.kill('SIGTERM');
+      });
+
       var extras = '';
       if (options.headless) extras += ' headlessly';
       if (options.proxy) extras += ' through ' + options.proxy;


### PR DESCRIPTION
On a CI box I noticed lots of chrome instances launched by prova still hanging around after tests exited. The commands used to launch the tests were:

```
prova test/test-*.js --browser --launch chrome --headless --quit
```

The change here attempts to send a SIGTERM signal to child process spawned by browser-launcher when the prova process exits.
