### PR TITLE
Allow the custom frame to have query parameters.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -14,6 +14,7 @@ var prettifyError = require("prettify-error");
 var WebSocket = require("faye-websocket");
 var mime = require("mime");
 var execFirst = require("./exec-first");
+var url = require('url');
 
 var nodeTemplate = require("./node-template");
 var nodeReporter = require("./node-reporter");
@@ -59,8 +60,9 @@ function start (files, command) {
   read.on('update', onSourceCodeChange.publish);
 
   if (command.frame) {
-    customFrameURL = path.join('/assets/in', command.frame);
-    routes[customFrameURL] = customFrame(command.frame);
+    var framePathname = url.parse(command.frame).pathname;
+    customFrameURL = path.join('/assets/in', framePathname);
+    routes[customFrameURL] = customFrame(framePathname);
   }
 
   routes['/assets/in/:filename([\\w\\.\\/-]+)'] = localAsset;
@@ -291,5 +293,5 @@ function customFrame (filename) {
 }
 
 function setContentType (req, res) {
-  res.setHeader('Content-Type', mime.lookup(req.url));
+  res.setHeader('Content-Type', mime.lookup(url.parse(req.url).pathname));
 }


### PR DESCRIPTION
There were two issues here:
- The `mime.lookup` call was returning test/octate because it didn't
  recognize the extension '.html?foo=bar
- If the route includes the query params, matchURL cannot properly match
  it.
