### PR TITLE
Allow custom frame to have query params

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -60,9 +60,10 @@ function start (files, command) {
   read.on('update', onSourceCodeChange.publish);
 
   if (command.frame) {
-    var framePathname = url.parse(command.frame).pathname;
-    customFrameURL = path.join('/assets/in', framePathname);
-    routes[customFrameURL] = customFrame(framePathname);
+    customFrameURL = path.join('/assets/in', command.frame);
+    var frameBasename = url.parse(command.frame).pathname;
+    var frameRoute = path.join('/assets/in', frameBasename);
+    routes[frameRoute] = customFrame(frameBasename);
   }
 
   routes['/assets/in/:filename([\\w\\.\\/-]+)'] = localAsset;


### PR DESCRIPTION
There were two issues here:
- The `mime.lookup call` was returning test/octate because it didn't recognize the extension `.html?foo=bar`
- If the route includes the query params, matchURL cannot properly match it.
