### PR TITLE
Update Dependencies

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -171,7 +171,7 @@ function index (req, res) {
 }
 
 function build (filename) {
-  var b = browserify();
+  var b = browserify({ debug: true });
   b.add(filename);
   return b;
 }
@@ -194,7 +194,7 @@ function run (req, res) {
     res.end(str);
   });
 
-  read.bundle({ debug: true }).on('error', function (error) {
+  read.bundle().on('error', function (error) {
     debug('Failed to browserify the source code. We\'re probably missing a module required. The error was:');
     process.stderr.write('\n    ');
     console.error(prettifyError(error, 0) || error);

--- a/lib/browserify-transforms.js
+++ b/lib/browserify-transforms.js
@@ -1,5 +1,6 @@
 var debug = require("local-debug")('browserify');
 var extname = require('path').extname;
+var browserify = require('browserify');
 var watchify = require('watchify');
 var path = require("path");
 
@@ -16,11 +17,21 @@ module.exports = function (files, command) {
   var ext = extname(files[0]);
   var transform = ext != '.js';
   var ret;
+  
+  var b = browserify({
+    debug: true,
+    cache: {},
+    packageCache: {},
+    fullPaths: true
+  });
+  
+  b.add(files);
+  b.bundle();
 
   if (transform) {
-    ret = watchify(files, { extensions: [ext, '.js', '.json'] });
+    ret = watchify(b, { extensions: [ext, '.js', '.json'] });
   } else {
-    ret = watchify(files);
+    ret = watchify(b);
   }
 
   if (transform) ret.transform(transformMap[ext]);
@@ -29,7 +40,7 @@ module.exports = function (files, command) {
     command.transform.split(',').forEach(function (name) {
       if (!name) return;
       debug('Transform "%s" enabled', name);
-      ret.transform(name);
+      ret.transform(path.join(process.cwd(), 'node_modules', name));
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "browser-launcher": "^1.0.0",
-    "browserify": "4.x",
+    "browserify": "^6.2.0",
     "component-delegate": "^0.2.3",
     "concat-stream": "^1.4.4",
     "default-debug": "0.0.0",
@@ -44,7 +44,7 @@
     "tape": "^3.0.0",
     "through": "~2.3.4",
     "user-agent-parser": "^0.6.0",
-    "watchify": "^0.10.1"
+    "watchify": "^2.1.1"
   },
   "keywords": [
     "testing",


### PR DESCRIPTION
The first commit updates all out of date dependencies except for Browserify and
Watchify which both require a rewrite in order to support the latest
versions.

The second commit updates both browserify and watchify.

Both have changed quite a bit since the versions tracked in the current iteration of Prova.
This required a bit of an overhaul to the current way that prova interfaces with the two.
Specifically it was neccessary to modify lib/browser.js and lib/browserify-transform.js to 
support the latest api.
