### PR TITLE
Add --browserify arg to proxy Browserify instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ Use comma to separate multiple plugins;
 $ node test -b --plugin foo,bar
 ```
 
+### Browserify Args
+
+Pass args directly to Browserify passing `--browserify` parameter;
+
+```bash
+$ node test -b --browserify "--extension .foo -t [ fooify --bar ]"
+```
+
+Can **not** be used with automatic transforms and plugins; `-t`,`--transform`,`-u`,`--plugin` args will be ignored by prova when passing `--browserify`.
+
 ### Custom Frame Documents
 
 When you're running the tests on the browser, Prova has an empty HTML template that loads and runs the JavaScript tests.
@@ -232,6 +242,7 @@ Assuming that you'll be running your tests on `:7559`, any requests to `/my-api`
           -v     --version       Show version and exit
           -h     --help          Show help and exit
                  --examples      Show example commands
+                 --browserify    Args string to instantiate Browserify. e.g node test -b --browserify "--extension .foo -t [ fooify --bar ]"
 ```
 
 ## Example Commands

--- a/lib/browserify-transforms.js
+++ b/lib/browserify-transforms.js
@@ -13,18 +13,22 @@ var transformMap = {
   '.ts': 'typescriptifier'
 };
 
+var browserifyOpts = {
+  debug: true,
+  cache: {},
+  packageCache: {},
+  fullPaths: true
+};
+
 module.exports = function (files, command) {
+  if (command.browserify) return proxyBrowserify(files)
+
   var ext = extname(files[0]);
   var transform = ext != '.js';
   var ret;
-  
-  var b = browserify({
-    debug: true,
-    cache: {},
-    packageCache: {},
-    fullPaths: true
-  });
-  
+
+  var b = browserify(browserifyOpts);
+
   b.add(files);
   b.bundle();
 
@@ -53,4 +57,23 @@ module.exports = function (files, command) {
   }
 
   return ret;
+};
+
+function proxyBrowserify(files){
+  var fromArgs = require('browserify/bin/args');
+  var argv = [];
+
+  for (var i=0; i<process.argv.length - 1; i++) {
+    if (process.argv[i] === '--browserify' ) {
+      argv = process.argv[i+1].split(' ');
+      break;
+    }
+  }
+
+  var b = fromArgs(argv, browserifyOpts);
+
+  b.add(files);
+  b.bundle();
+
+  return watchify(b);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prova",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Test runner based on Tape and Browserify",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Enable instantiating Browserify from args.

If `--browserify` command is passed, it will proxy instantiation of Browserify and ignore automatic prova extensions, transforms and plugins.

This request constitutes a 'feature' version bump in package.json.

README.md has also been updated to document the change.
